### PR TITLE
using for...in when traverse object with less properties

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -11,17 +11,17 @@ var signature = require('cookie-signature');
  */
 
 exports.signedCookies = function(obj, secret){
-  var ret = {};
-  Object.keys(obj).forEach(function(key){
-    var val = obj[key];
+  var ret = {}, val;
+  for (var i in obj) {
+    val = obj[i];
     if (0 == val.indexOf('s:')) {
       val = signature.unsign(val.slice(2), secret);
       if (val) {
-        ret[key] = val;
-        delete obj[key];
+        ret[i] = val;
+        delete obj[i];
       }
     }
-  });
+  }
   return ret;
 };
 
@@ -34,11 +34,14 @@ exports.signedCookies = function(obj, secret){
  */
 
 exports.JSONCookies = function(obj){
-  Object.keys(obj).forEach(function(key){
-    var val = obj[key];
-    var res = exports.JSONCookie(val);
-    if (res) obj[key] = res;
-  });
+  var val, res;
+  for (var i in obj) {
+    val = obj[i];
+    res = exports.JSONCookie(val);
+    if (res) {
+      obj[i] = res;
+    }
+  }
   return obj;
 };
 


### PR DESCRIPTION
performance benchmark when traverse object:

http://jsperf.com/delete-properties-or-create-new-one

usually, req.cookies do not contain more then 10 cookie, so traverse these object, we should using for...in 
