### PR TITLE
set secret default to be an empty string

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,9 @@ var parse = require('./lib/parse');
  */
 
 exports = module.exports = function cookieParser(secret, options){
+  if (typeof secret !== 'string') {
+    secret = '';
+  }
   return function cookieParser(req, res, next) {
     if (req.cookies) return next();
     var cookies = req.headers.cookie;


### PR DESCRIPTION
secret should have an default string value, because in `cookie-signature`:

```
exports.unsign = function(val, secret){
  if ('string' != typeof val) throw new TypeError('cookie required');
  if ('string' != typeof secret) throw new TypeError('secret required');
```

it will throw err when secret is not string

a real case:

domain.com have 2 website: A & B
when site A set an signed cookie `sid` ,  and user visited site B which didn't set secret (no login needed, but parse cookie),   it will throw exception;
