### PR TITLE
added typeof undefined check in signedCookie

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -41,7 +41,7 @@ exports.signedCookies = function(obj, secret){
  */
 
 exports.signedCookie = function(str, secret){
-  return str.substr(0, 2) === 's:'
+  return typeof str !== 'undefined' && str.substr(0, 2) === 's:'
     ? signature.unsign(str.slice(2), secret)
     : str;
 };


### PR DESCRIPTION
```
Result of fix:
Cookie is invalid.

Error fixed:
return str.substr(0, 2) === 's:'
            ^
TypeError: Cannot read property 'substr' of undefined
```