### PR TITLE
Add Secret Function Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ app.use(cookieParser())
 
 ### cookieParser(secret, options)
 
-- `secret` a string or array used for signing cookies. This is optional and if not specified, will not parse signed cookies. If a string is provided, this is used as the secret. If an array is provided, an attempt will be made to unsign the cookie with each secret in order.
+- `secret` a string, array of strings, or a function used for signing cookies. This is optional and if not specified, will not parse signed cookies. If a string is provided, this is used as the secret. If an array is provided, an attempt will be made to unsign the cookie with each secret in order. If a string is provided, the return value will be used just like providing a string or array of strings.
 - `options` an object that is passed to `cookie.parse` as the second option. See [cookie](https://www.npmjs.org/package/cookie) for more information.
   - `decode` a function to decode the value of the cookie
 

--- a/index.js
+++ b/index.js
@@ -42,8 +42,17 @@ function cookieParser(secret, options) {
 
     var cookies = req.headers.cookie;
     var secrets = !secret || Array.isArray(secret)
-      ? (secret || [])
-      : [secret];
+        ? (secret || [])
+        : [secret];
+
+    if (typeof secret === 'function') {
+      var secretValue = secret(req);
+      if (Array.isArray(secretValue)) {
+        secrets = secretValue;
+      } else {
+        secrets = [secretValue];
+      }
+    }
 
     req.secret = secrets[0];
     req.cookies = Object.create(null);

--- a/test/cookieParser.js
+++ b/test/cookieParser.js
@@ -119,7 +119,7 @@ describe('cookieParser()', function(){
     rotateKey();
     var rotateKeyIntervalId = setInterval(rotateKey, 500);
 
-    var functionServer = createServer(function(req) {
+    var functionServer = createServer(function() {
       return rotatingSecretKey;
     });
     functionServer.listen();
@@ -132,7 +132,6 @@ describe('cookieParser()', function(){
       request(functionServer)
           .get('/signed')
           .set('Cookie', 'foo=s:' + signature.sign('foobarbaz', rotatingSecretKey))
-          .set('Host', 'test.example.com')
           .expect(200, '{"foo":"foobarbaz"}', done);
     });
 
@@ -140,7 +139,6 @@ describe('cookieParser()', function(){
       request(functionServer)
           .get('/')
           .set('Cookie', 'foo=s:' + signature.sign('foobarbaz', rotatingSecretKey))
-          .set('Host', 'test.example.com')
           .expect(200, '{}', done);
     });
 
@@ -149,7 +147,6 @@ describe('cookieParser()', function(){
       request(server)
           .get('/signed')
           .set('Cookie', 'foo=' + signedValue + '3')
-          .set('Host', 'test.example.com')
           .expect(200, '{}', function(err){
             if (err) return done(err);
             request(server)
@@ -160,14 +157,13 @@ describe('cookieParser()', function(){
     });
 
     it('should try multiple secrets', function(done){
-      var multipleSecretsServer = createServer(function(req) {
+      var multipleSecretsServer = createServer(function() {
         return ['keyboard cat', rotatingSecretKey];
       });
       multipleSecretsServer.listen();
       request(multipleSecretsServer)
           .get('/signed')
           .set('Cookie', 'foo=s:' + signature.sign('foobarbaz', rotatingSecretKey))
-          .set('Host', 'test.example.com')
           .expect(200, '{"foo":"foobarbaz"}', done);
     });
   });


### PR DESCRIPTION
This PR is being done in conjunction with expressjs/session#214. Currently, in order to vary the secret value for the cookie parser instantiations I have to memoize them. I'd much rather be able to set the secret based upon the request. This adds that functionality and tests around it.
