### PR TITLE
docs: consistent use of '

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ var app = express()
 app.use(cookieParser())
 
 app.get('/', function(req, res) {
-  console.log("Cookies: ", req.cookies)
+  console.log('Cookies: ', req.cookies)
 })
 
 app.listen(8080)


### PR DESCRIPTION
It's not super important, but normally I think it's good if the code examples are consistent with `'` just to not give newcomers bad habits.