### PR TITLE
Show how to access signedCookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,10 @@ var app = express()
 app.use(cookieParser())
 
 app.get('/', function(req, res) {
+  // Cookies that has not been signed with a secret
   console.log('Cookies: ', req.cookies)
+  // Cookies that has been signed with res.cookie('key', 'value', { signed: true })
+  console.log('Signed Cookies: ', req.signedCookies)
 })
 
 app.listen(8080)


### PR DESCRIPTION
Show how to access the signedCookies as it is not clear from this repository and as expressjs.com links to this page to read more instead of linking to the `req.signedCookies` it is easy to get confused and miss how to read signed cookies.
