### PR TITLE
Clarify the description of cookieParser.JSONCookie.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Parse a cookie value as a JSON cookie. This will return the parsed JSON value if
 
 ### cookieParser.JSONCookies(cookies)
 
-Given an object, this will iterate over the keys and call `JSONCookie` on each value. This will return the same object passed in.
+Given an object, this will iterate over the keys and call `JSONCookie` on each value, replacing the original value with the parsed value. This returns the same object that was passed in.
 
 ### cookieParser.signedCookie(str, secret)
 


### PR DESCRIPTION
It had to read the source code to understand what cookieParser.JSONCookie was doing with the parsed results. I figured I would add a bit of clarification.