### PR TITLE
Update cookie dependency for SameSite=None

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "middleware"
   ],
   "dependencies": {
-    "cookie": "0.3.1",
+    "cookie": "0.4.0",
     "cookie-signature": "1.0.6"
   },
   "devDependencies": {


### PR DESCRIPTION
The 0.4.0 release of [`jshttp/cookie`](https://github.com/jshttp/cookie) adds support for the `SameSite=None` attribute as per https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03. This pull request updates the dependency on `cookie`.

I'm happy to update the other dependencies as the test suite happily passes with current versions for everything, but I didn't want to be over enthusiastic there!