### PR TITLE
Upgrade cookie to 0.5.0 

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,10 @@
 unreleased
 ==========
 
+  * deps: cookie@0.5.0
+    - Fix expires option to reject invalid dates
+    - perf: improve default decode speed
+    - perf: remove slow string split in parse
   * deps: cookie@0.4.2
     - pref: read value only when assigning in parse
     - pref: remove unnecessary regexp in parse

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "middleware"
   ],
   "dependencies": {
-    "cookie": "0.4.2",
+    "cookie": "0.5.0",
     "cookie-signature": "1.0.6"
   },
   "devDependencies": {


### PR DESCRIPTION
Hey! Noticed that the package `cookie` that we depend on has the latest version available that we can upgrade on which has a few perf benefits.

This although primarily comes from us using `cookie-parser` in our project which inturns is using an outdated version of the `cookie` package, while we're on the latest version & not able to de-dupe this to resolve to a single version leading to duplicate versions coming as part of the bundle.

Here's the changelog:
https://github.com/jshttp/cookie/releases

<img width="936" alt="Screenshot 2023-03-13 at 4 13 04 PM" src="https://user-images.githubusercontent.com/8057916/224679144-21c2773b-fb48-4510-b98e-87521018751e.png">


- [x] I ran the tests locally & they seem to have been passing.

Open to suggestions.