### PR TITLE
Add support for encrypted cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,27 @@
 [![Build Status][ci-image]][ci-url]
 [![Test Coverage][coveralls-image]][coveralls-url]
 
-Parse `Cookie` header and populate `req.cookies` with an object keyed by the
-cookie names. Optionally you may enable signed cookie support by passing a
-`secret` string, which assigns `req.secret` so it may be used by other
-middleware.
+## Features
+- Parse `Cookie` header and populate `req.cookies` with an object keyed by the
+cookie names.
+- JSON cookie parsing support
+
+Optionally, when `secret` is provided:
+- Signed cookie parsing support
+- Encrypted cookie parsing support
+- Multiple secrets support
+- The `secret` is assigned to `req.secret` so it may be used by other middleware.
+- The `secretEncoding`, if provided, is assigned to `req.secretEncoding` so it may be used by other middleware.
 
 ## Installation
 
 ```sh
 $ npm install cookie-parser
+```
+
+Yarn
+```sh
+$ yarn add cookie-parser
 ```
 
 ## API
@@ -22,18 +34,26 @@ $ npm install cookie-parser
 var cookieParser = require('cookie-parser')
 ```
 
-### cookieParser(secret, options)
+ESM
+```js
+import cookieParser from 'cookie-parser'
+```
+
+### **cookieParser(secret, options)**
 
 Create a new cookie parser middleware function using the given `secret` and
 `options`.
 
-- `secret` a string or array used for signing cookies. This is optional and if
-  not specified, will not parse signed cookies. If a string is provided, this
-  is used as the secret. If an array is provided, an attempt will be made to
-  unsign the cookie with each secret in order.
-- `options` an object that is passed to `cookie.parse` as the second option. See
+- `secret` (string | array) *Optional* - used for signing cookies. If not
+  specified, signed and encrypted cookies will not be parsed. If a string is
+  provided, this is used as the secret. If an array is provided, an attempt
+  will be made to unsign the cookie with each secret in order.
+- `options` (object) passed to `cookie.parse` as the second option. See
   [cookie](https://www.npmjs.org/package/cookie) for more information.
   - `decode` a function to decode the value of the cookie
+  - `secretEncoding` the string encoding scheme for all the secrets. Default is
+  'utf8'. Examples: 'hex', 'utf8', 'base64'. See
+  [Nodejs crypto.BufferEncoding](https://nodejs.org/api/buffer.html#buffers-and-character-encodings) for more info.
 
 The middleware will parse the `Cookie` header on the request and expose the
 cookie data as the property `req.cookies` and, if a `secret` was provided, as
@@ -41,48 +61,58 @@ the property `req.signedCookies`. These properties are name value pairs of the
 cookie name to cookie value.
 
 When `secret` is provided, this module will unsign and validate any signed cookie
-values and move those name value pairs from `req.cookies` into `req.signedCookies`.
-A signed cookie is a cookie that has a value prefixed with `s:`. Signed cookies
-that fail signature validation will have the value `false` instead of the tampered
-value.
+values, decrypt them if they were encrypted, and move those name value pairs from `req.cookies` into `req.signedCookies`.
+A signed cookie is a cookie that has a value prefixed with `s:`. An encrypted cookie
+has the prefix `e:`. Signed cookies that fail signature validation will have the value `false` instead of the tampered value. Encrypted cookies are also expected to be signed
+and will return false if signature validation or decryption returns false.
 
 In addition, this module supports special "JSON cookies". These are cookie where
 the value is prefixed with `j:`. When these values are encountered, the value will
 be exposed as the result of `JSON.parse`. If parsing fails, the original value will
 remain.
 
-### cookieParser.JSONCookie(str)
+### **cookieParser.JSONCookie(str)**
 
 Parse a cookie value as a JSON cookie. This will return the parsed JSON value
 if it was a JSON cookie, otherwise, it will return the passed value.
 
-### cookieParser.JSONCookies(cookies)
+### **cookieParser.JSONCookies(cookies)**
 
 Given an object, this will iterate over the keys and call `JSONCookie` on each
 value, replacing the original value with the parsed value. This returns the
 same object that was passed in.
 
-### cookieParser.signedCookie(str, secret)
+### **cookieParser.signedCookie(str, secret, secretEncoding)**
 
 Parse a cookie value as a signed cookie. This will return the parsed unsigned
 value if it was a signed cookie and the signature was valid. If the value was
 not signed, the original value is returned. If the value was signed but the
-signature could not be validated, `false` is returned.
+signature could not be validated, `false` is returned. If the value was
+encrypted and did not pass signature validation or decryption, `false` is
+returned.
 
-The `secret` argument can be an array or string. If a string is provided, this
-is used as the secret. If an array is provided, an attempt will be made to
-unsign the cookie with each secret in order.
+- `str` (string) cookie value to parse
+- `secret` (array | string) If a string is provided, this is used as the secret.
+If an array is provided, an attempt will be made to unsign the cookie with each
+secret in order.
+- `secretEncoding` (string) *Optional*: the string encoding scheme for the secret(s).
+  Default is 'utf8'. Examples: 'hex', 'utf8', 'base64'. See
+  [Nodejs crypto.BufferEncoding](https://nodejs.org/api/buffer.html#buffers-and-character-encodings) for more info.
 
-### cookieParser.signedCookies(cookies, secret)
+### **cookieParser.signedCookies(cookies, secret, secretEncoding)**
 
 Given an object, this will iterate over the keys and check if any value is a
-signed cookie. If it is a signed cookie and the signature is valid, the key
-will be deleted from the object and added to the new object that is returned.
+signed or encrypted cookie. If it is a signed cookie and the signature is valid,
+or it is an encrypted cookie, whose signature is valid and can be decrypted by the
+secret(s) provided, the key will be deleted from the object and added to the new object that is returned.
 
-The `secret` argument can be an array or string. If a string is provided, this
+- `cookies` (object) object to iterate over
+- `secret` (array | string) If a string is provided, this
 is used as the secret. If an array is provided, an attempt will be made to
 unsign the cookie with each secret in order.
-
+- `secretEncoding` (string) *Optional*: the string encoding scheme for the secret(s).
+  Default is 'utf8'. Examples: 'hex', 'utf8', 'base64'. See
+  [Nodejs crypto.BufferEncoding](https://nodejs.org/api/buffer.html#buffers-and-character-encodings) for more info.
 ## Example
 
 ```js

--- a/index.js
+++ b/index.js
@@ -132,12 +132,12 @@ function JSONCookies (obj) {
  * @public
  */
 
-function signedCookie (str, secret, secretEncoding = 'utf8') {
+function signedCookie (str, secret, secretEncoding) {
   if (typeof str !== 'string') {
     return undefined
   }
 
-  if (!['s:', 'e:'].includes(str.substring(0, 2))) {
+  if (str.substring(0, 2) !== 's:' && str.substring(0, 2) !== 'e:') {
     return str
   }
 
@@ -175,7 +175,7 @@ function signedCookie (str, secret, secretEncoding = 'utf8') {
  * @public
  */
 
-function signedCookies (obj, secret, secretEncoding = 'utf8') {
+function signedCookies (obj, secret, secretEncoding) {
   var cookies = Object.keys(obj)
   var dec
   var key

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   ],
   "dependencies": {
     "cookie": "0.4.2",
-    "cookie-signature": "1.0.6"
+    "cookie-signature": "1.0.6",
+    "symmetric-cipher.js": "2.0.0"
   },
   "devDependencies": {
     "eslint": "7.32.0",
@@ -24,7 +25,7 @@
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-promise": "4.3.1",
     "eslint-plugin-standard": "4.1.0",
-    "mocha": "9.2.1",
+    "mocha": "^9.2.2",
     "nyc": "15.1.0",
     "supertest": "6.1.6"
   },

--- a/test/cookieParser.js
+++ b/test/cookieParser.js
@@ -433,7 +433,7 @@ describe('cookieParser.signedCookies(obj, secret, secretEncoding)', function () 
   })
 })
 
-function createServer (secret, options = {}) {
+function createServer (secret, options) {
   var _parser = cookieParser(secret, options)
   return http.createServer(function (req, res) {
     _parser(req, res, function (err) {
@@ -443,7 +443,7 @@ function createServer (secret, options = {}) {
         return
       }
 
-      var cookies = ['/signed', '/encrypted'].includes(req.url)
+      var cookies = (req.url === '/signed' || req.url === '/encrypted')
         ? req.signedCookies
         : req.cookies
       res.end(JSON.stringify(cookies))

--- a/test/cookieParser.js
+++ b/test/cookieParser.js
@@ -4,6 +4,24 @@ var cookieParser = require('..')
 var http = require('http')
 var request = require('supertest')
 var signature = require('cookie-signature')
+var cipher = require('symmetric-cipher.js')
+/**
+ * 'foobarbaz' encrypted and signed with 'keyboard cat'
+ */
+var signedCipher1 = '6JQ2n1bwxiuAUPaFpkBtqw==:FN4NRkW8yzMVti4WsN5c5Q==.F3J2iQnR3hnEpAukADFQdUgFjbdQnv50g+Yw1+IlYlk'
+/**
+ * 'foobar' encrypted and signed with 'keyboard cat'
+ */
+var signedCipher2 = 'dQgKRe263NFi8g1i2nS6YQ==:IqLvIuFB/0Ish5NlmI/tYw==.2Ge32QKb5pQR2XQQ0uD8iUNpKwfPniru9xOy2LZTYd4'
+/**
+ * 'foobar' encrypted and signed with 'nyan cat'
+ */
+var signedCipher3 = 'CQRD3Ccd327E9exNxBMCrQ==:v7CAQBa4umh7MFcCBPD7yA==.l1T6Rp6Rjs+GMuWU9cN5i4V4RUDsVwG7cp0KXRds2I8'
+
+/**
+ * cipher from signedCipher1 tampered and resigned
+ */
+var tamperedCipher = '6JQ2n1bwxiuAUPaFpkBtqw==:FN4NRkW8yzMVti4WsN5c12==.NfOQXrzxfUD8DyD2sk0E9iVq7OwS931eUza7HUEvYXo'
 
 describe('cookieParser()', function () {
   it('should export JSONCookies function', function () {
@@ -102,14 +120,71 @@ describe('cookieParser()', function () {
             .expect(200, '{"foo":"foobarbaz.CP7AWaXDfAKIRfH49dQzKJx7sKzzSoPq7/AcBBRVwlI3"}', done)
         })
     })
+
+    describe('when the cookies are encrypted', function () {
+      it('should populate req.signedCookies', function (done) {
+        request(createServer('keyboard cat'))
+          .get('/encrypted')
+          .set('Cookie', 'foo=e:' + signedCipher1)
+          .expect(200, '{"foo":"foobarbaz"}', done)
+      })
+
+      it('should remove the encrypted value from req.cookies', function (done) {
+        request(createServer('keyboard cat'))
+          .get('/')
+          .set('Cookie', 'foo=e:' + signedCipher1)
+          .expect(200, '{}', done)
+      })
+
+      it('should omit invalid ciphers', function (done) {
+        var server = createServer('keyboard cat')
+
+        request(server)
+          .get('/encrypted')
+          .set('Cookie', 'foo=' + signedCipher1 + '3')
+          .expect(200, '{}', function (err) {
+            if (err) return done(err)
+            request(server)
+              .get('/')
+              .set('Cookie', 'foo=' + signedCipher1 + '3')
+              .expect(200, '{"foo":"' + signedCipher1 + '3"}', done)
+          })
+      })
+
+      describe('when key encoding is specified', function () {
+        /**
+         * 'foobarbaz' encrypted with base64 version of 'keboard cat' (a2V5Ym9hcmQgY2F0)
+         */
+        var cipherText = 'dQgKRe263NFi8g1i2nS6YQ==:IqLvIuFB/0Ish5NlmI/tYw=='
+        /**
+         * 'keyboard cat' in base64 (a2V5Ym9hcmQgY2F0)
+         */
+        var base64Secret = cipher.decodeKey('keyboard cat').toString('base64')
+
+        it('should populate req.signedCookies', function (done) {
+          request(createServer(base64Secret, { secretEncoding: 'base64' }))
+            .get('/encrypted')
+            .set('Cookie', 'foo=e:' + signature.sign(cipherText, base64Secret))
+            .expect(200, '{"foo":"foobar"}', done)
+        })
+
+        it('should omit unmatching secret encoding', function (done) {
+          // No secret encoding specified is equivalent to passing utf8
+          request(createServer(base64Secret))
+            .get('/encrypted')
+            .set('Cookie', 'foo=e:' + signature.sign(cipherText, base64Secret))
+            .expect(200, '{"foo":false}', done)
+        })
+      })
+    })
   })
 
   describe('when multiple secrets are given', function () {
     it('should populate req.signedCookies', function (done) {
       request(createServer(['keyboard cat', 'nyan cat']))
         .get('/signed')
-        .set('Cookie', 'buzz=s:foobar.N5r0C3M8W+IPpzyAJaIddMWbTGfDSO+bfKlZErJ+MeE; fizz=s:foobar.JTCAgiMWsnuZpN3mrYnEUjXlGxmDi4POCBnWbRxse88')
-        .expect(200, '{"buzz":"foobar","fizz":"foobar"}', done)
+        .set('Cookie', 'buzz=s:foobar.N5r0C3M8W+IPpzyAJaIddMWbTGfDSO+bfKlZErJ+MeE; fizz=s:foobar.JTCAgiMWsnuZpN3mrYnEUjXlGxmDi4POCBnWbRxse88; bar=e:' + signedCipher2 + '; baz=e:' + signedCipher3 + ';')
+        .expect(200, '{"buzz":"foobar","fizz":"foobar","bar":"foobar","baz":"foobar"}', done)
     })
   })
 
@@ -162,7 +237,7 @@ describe('cookieParser.JSONCookie(str)', function () {
   })
 })
 
-describe('cookieParser.signedCookie(str, secret)', function () {
+describe('cookieParser.signedCookie(str, secret, secretEncoding)', function () {
   it('should return undefined for non-string arguments', function () {
     assert.strictEqual(cookieParser.signedCookie(undefined, 'keyboard cat'), undefined)
     assert.strictEqual(cookieParser.signedCookie(null, 'keyboard cat'), undefined)
@@ -180,15 +255,31 @@ describe('cookieParser.signedCookie(str, secret)', function () {
 
   it('should return false for tampered signed string', function () {
     assert.strictEqual(cookieParser.signedCookie('s:foobaz.N5r0C3M8W+IPpzyAJaIddMWbTGfDSO+bfKlZErJ+MeE', 'keyboard cat'), false)
+    assert.strictEqual(cookieParser.signedCookie('e:' + signedCipher1 + '1', 'keyboard cat'), false)
+  })
+
+  it('should return false for tampered cipher', function () {
+    assert.strictEqual(cookieParser.signedCookie('e:' + tamperedCipher, 'keyboard cat'), false)
   })
 
   it('should return unsigned value for signed string', function () {
     assert.strictEqual(cookieParser.signedCookie('s:foobar.N5r0C3M8W+IPpzyAJaIddMWbTGfDSO+bfKlZErJ+MeE', 'keyboard cat'), 'foobar')
   })
 
+  it('should return unsigned and unencrypted value for encrypted string', function () {
+    assert.strictEqual(cookieParser.signedCookie('e:' + signedCipher2, 'keyboard cat'), 'foobar')
+  })
+
   describe('when secret is an array', function () {
     it('should return false for tampered signed string', function () {
       assert.strictEqual(cookieParser.signedCookie('s:foobaz.N5r0C3M8W+IPpzyAJaIddMWbTGfDSO+bfKlZErJ+MeE', [
+        'keyboard cat',
+        'nyan cat'
+      ]), false)
+    })
+
+    it('should return false for tampered cipher', function () {
+      assert.strictEqual(cookieParser.signedCookie('e:' + tamperedCipher, [
         'keyboard cat',
         'nyan cat'
       ]), false)
@@ -201,16 +292,51 @@ describe('cookieParser.signedCookie(str, secret)', function () {
       ]), 'foobar')
     })
 
+    it('should return unsigned and unencrypted value for first secret', function () {
+      assert.strictEqual(cookieParser.signedCookie('e:' + signedCipher2, [
+        'keyboard cat',
+        'nyan cat'
+      ]), 'foobar')
+    })
+
     it('should return unsigned value for second secret', function () {
       assert.strictEqual(cookieParser.signedCookie('s:foobar.JTCAgiMWsnuZpN3mrYnEUjXlGxmDi4POCBnWbRxse88', [
         'keyboard cat',
         'nyan cat'
       ]), 'foobar')
     })
+
+    it('should return unsigned and unencrypted value for second secret', function () {
+      assert.strictEqual(cookieParser.signedCookie('e:' + signedCipher3, [
+        'keyboard cat',
+        'nyan cat'
+      ]), 'foobar')
+    })
+  })
+
+  describe('when secret encoding is specified', function () {
+    it('should return false for same key but different specified encoding', function () {
+      assert.strictEqual(cookieParser.signedCookie('e:' + signedCipher2, 'keyboard cat', 'base64'), false)
+    })
+
+    it('should return unencrypted string for same key with same encoding', function () {
+      assert.strictEqual(cookieParser.signedCookie('e:' + signedCipher2, 'keyboard cat', 'utf8'), 'foobar')
+    })
+
+    it('should return unencrypted string for same key in different encoding', function () {
+      // Will be signed with the key as utf8 but encrypted and decrypted with the key as base64
+      var cipherText = 'dQgKRe263NFi8g1i2nS6YQ==:IqLvIuFB/0Ish5NlmI/tYw=='
+      /**
+       * 'keyboard cat' in base64 (a2V5Ym9hcmQgY2F0)
+       */
+      var base64Secret = cipher.decodeKey('keyboard cat').toString('base64')
+      assert.strictEqual(cookieParser.signedCookie('e:' + signature.sign(cipherText, 'keyboard cat'), 'keyboard cat', 'utf8'), 'foobar')
+      assert.strictEqual(cookieParser.signedCookie('e:' + signature.sign(cipherText, base64Secret), base64Secret, 'base64'), 'foobar')
+    })
   })
 })
 
-describe('cookieParser.signedCookies(obj, secret)', function () {
+describe('cookieParser.signedCookies(obj, secret, secretEncoding)', function () {
   it('should ignore non-signed strings', function () {
     assert.deepEqual(cookieParser.signedCookies({}, 'keyboard cat'), {})
     assert.deepEqual(cookieParser.signedCookies({ foo: 'bar' }, 'keyboard cat'), {})
@@ -218,6 +344,12 @@ describe('cookieParser.signedCookies(obj, secret)', function () {
 
   it('should include tampered strings as false', function () {
     assert.deepEqual(cookieParser.signedCookies({ foo: 's:foobaz.N5r0C3M8W+IPpzyAJaIddMWbTGfDSO+bfKlZErJ+MeE' }, 'keyboard cat'), {
+      foo: false
+    })
+    assert.deepEqual(cookieParser.signedCookies({ foo: 'e:' + signedCipher2 + '1' }, 'keyboard cat'), {
+      foo: false
+    })
+    assert.deepEqual(cookieParser.signedCookies({ foo: 'e:' + tamperedCipher }, 'keyboard cat'), {
       foo: false
     })
   })
@@ -228,63 +360,81 @@ describe('cookieParser.signedCookies(obj, secret)', function () {
     })
   })
 
-  it('should remove signed strings from original object', function () {
+  it('should include unencrypted strings', function () {
+    assert.deepEqual(cookieParser.signedCookies({ foo: 'e:' + signedCipher2 }, 'keyboard cat'), {
+      foo: 'foobar'
+    })
+  })
+
+  it('should remove signed and encrypted strings from original object', function () {
     var obj = {
-      foo: 's:foobar.N5r0C3M8W+IPpzyAJaIddMWbTGfDSO+bfKlZErJ+MeE'
+      foo: 's:foobar.N5r0C3M8W+IPpzyAJaIddMWbTGfDSO+bfKlZErJ+MeE',
+      bar: 'e:' + signedCipher2
     }
 
-    assert.deepEqual(cookieParser.signedCookies(obj, 'keyboard cat'), { foo: 'foobar' })
+    assert.deepEqual(cookieParser.signedCookies(obj, 'keyboard cat'), { foo: 'foobar', bar: 'foobar' })
     assert.deepEqual(obj, {})
   })
 
   it('should remove tampered strings from original object', function () {
     var obj = {
-      foo: 's:foobaz.N5r0C3M8W+IPpzyAJaIddMWbTGfDSO+bfKlZErJ+MeE'
+      foo: 's:foobaz.N5r0C3M8W+IPpzyAJaIddMWbTGfDSO+bfKlZErJ+MeE',
+      bar: 'e:' + signedCipher2 + '1',
+      baz: 'e:' + tamperedCipher
     }
 
-    assert.deepEqual(cookieParser.signedCookies(obj, 'keyboard cat'), { foo: false })
+    assert.deepEqual(cookieParser.signedCookies(obj, 'keyboard cat'), { foo: false, bar: false, baz: false })
     assert.deepEqual(obj, {})
   })
 
-  it('should leave unsigned string in original object', function () {
+  it('should leave unsigned and unencrypted strings in original object', function () {
     var obj = {
       fizz: 'buzz',
-      foo: 's:foobar.N5r0C3M8W+IPpzyAJaIddMWbTGfDSO+bfKlZErJ+MeE'
+      foo: 's:foobar.N5r0C3M8W+IPpzyAJaIddMWbTGfDSO+bfKlZErJ+MeE',
+      bar: 'e:' + signedCipher2
     }
 
-    assert.deepEqual(cookieParser.signedCookies(obj, 'keyboard cat'), { foo: 'foobar' })
+    assert.deepEqual(cookieParser.signedCookies(obj, 'keyboard cat'), { foo: 'foobar', bar: 'foobar' })
     assert.deepEqual(obj, { fizz: 'buzz' })
   })
 
   describe('when secret is an array', function () {
-    it('should include unsigned strings for matching secrets', function () {
+    it('should include unsigned and unencrypted strings for matching secrets', function () {
       var obj = {
         buzz: 's:foobar.N5r0C3M8W+IPpzyAJaIddMWbTGfDSO+bfKlZErJ+MeE',
-        fizz: 's:foobar.JTCAgiMWsnuZpN3mrYnEUjXlGxmDi4POCBnWbRxse88'
+        fizz: 's:foobar.JTCAgiMWsnuZpN3mrYnEUjXlGxmDi4POCBnWbRxse88',
+        bar: 'e:' + signedCipher2,
+        baz: 'e:' + signedCipher3
       }
 
       assert.deepEqual(cookieParser.signedCookies(obj, ['keyboard cat']), {
         buzz: 'foobar',
-        fizz: false
+        fizz: false,
+        bar: 'foobar',
+        baz: false
       })
     })
 
-    it('should include unsigned strings for all secrets', function () {
+    it('should include unsigned and unencrypted strings for all secrets', function () {
       var obj = {
         buzz: 's:foobar.N5r0C3M8W+IPpzyAJaIddMWbTGfDSO+bfKlZErJ+MeE',
-        fizz: 's:foobar.JTCAgiMWsnuZpN3mrYnEUjXlGxmDi4POCBnWbRxse88'
+        fizz: 's:foobar.JTCAgiMWsnuZpN3mrYnEUjXlGxmDi4POCBnWbRxse88',
+        bar: 'e:' + signedCipher2,
+        baz: 'e:' + signedCipher3
       }
 
       assert.deepEqual(cookieParser.signedCookies(obj, ['keyboard cat', 'nyan cat']), {
         buzz: 'foobar',
-        fizz: 'foobar'
+        fizz: 'foobar',
+        bar: 'foobar',
+        baz: 'foobar'
       })
     })
   })
 })
 
-function createServer (secret) {
-  var _parser = cookieParser(secret)
+function createServer (secret, options = {}) {
+  var _parser = cookieParser(secret, options)
   return http.createServer(function (req, res) {
     _parser(req, res, function (err) {
       if (err) {
@@ -293,7 +443,7 @@ function createServer (secret) {
         return
       }
 
-      var cookies = req.url === '/signed'
+      var cookies = ['/signed', '/encrypted'].includes(req.url)
         ? req.signedCookies
         : req.cookies
       res.end(JSON.stringify(cookies))


### PR DESCRIPTION
I'm proposing support for encrypted cookies in Express. I followed an approach similar to the cookie signing code. I created the package [symmetric-cipher.js](https://www.npmjs.com/package/symmetric-cipher.js) which has the encrypt and decrypt functionality. It uses symmetric encryption ('AES-256-CBC') and creates a sha256 hash of the key if the key length is not 32 bytes (256 bits). Encrypted cookies are also signed, to prevent wasting computing resources on a decryption attempt if the cookie has been tampered with. Encryption happens on top of JSON serialisation for JSON cookies so they should decrypt back to `j:`. I have opened a [PR](https://github.com/expressjs/express/pull/5156) to add encrypted cookie support to the main express library.

I have also added the secretEncosing option so secrets can be used for encryption in encoding schemes like 'base64' and 'hex'. Since cookie-signature@1.0.6 only accepts UTF8 strings, the signing and unsigning is done using the secret as a UTF string, and then encryption and decryption use the specified encoding.