### PR TITLE
Allow 'partitioned' flag (bump dependencies)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "middleware"
   ],
   "dependencies": {
-    "cookie": "0.4.2",
-    "cookie-signature": "1.0.6"
+    "cookie": "0.6.0",
+    "cookie-signature": "1.2.1"
   },
   "devDependencies": {
     "eslint": "7.32.0",


### PR DESCRIPTION
Chrome is starting a slow rollout of [Cookies Having Independent Partitioned State (CHIPS)](https://developers.google.com/privacy-sandbox/3pcd/chips), which requires the use of a new flag `partitioned`. Updated dependency `cookie` which [adds this in version 0.6.0](https://github.com/jshttp/cookie/releases/tag/v0.6.0). Also updated `cookie-signature` to the latest version.