### PR TITLE
Fixed signed cookie value assigning with undefined or false

### DIFF
--- a/index.js
+++ b/index.js
@@ -173,7 +173,9 @@ function signedCookies (obj, secret) {
     dec = signedCookie(val, secret)
 
     if (val !== dec) {
-      ret[key] = dec
+      if (dec) {
+        ret[key] = dec
+      }
       delete obj[key]
     }
   }


### PR DESCRIPTION
### This is a bug fix which is related to issue #108 . Detailed description can be found over the issue about the bug details.

- Fixed signed cookie value assigning with `undefined` or `false` when cookie secret is updated.
- Handled and fixed the validation of `undefined` and `false` values in `signedCookies (obj, secret){}` function of `cookie-parser` module in such a way that all signed cookies with invalid signatures can be ignored and should neither be included in `req.cookies` nor in `req.signedCookies` objects as they become invalid post cookie secret updation.