### PR TITLE
Refactor: use slice() instead of deprecated substr() to avoid future issues

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ function cookieParser (secret, options) {
  */
 
 function JSONCookie (str) {
-  if (typeof str !== 'string' || str.substr(0, 2) !== 'j:') {
+  if (typeof str !== 'string' || str.slice(0, 2) !== 'j:') {
     return undefined
   }
 
@@ -131,7 +131,7 @@ function signedCookie (str, secret) {
     return undefined
   }
 
-  if (str.substr(0, 2) !== 's:') {
+  if (str.slice(0, 2) !== 's:') {
     return str
   }
 


### PR DESCRIPTION
### What does this PR do?
This pull request replaces all occurrences of the deprecated `substr()` method with `slice()` in the codebase.

### Why is this needed?
The `substr()` method is deprecated and may lead to issues or warnings in future JavaScript versions. This update ensures the code remains future-proof and compliant with modern JavaScript standards.

### How does it address the issue?
Each instance of `substr()` has been refactored to `slice()` to maintain the same functionality.

### Are there any side effects?
This change should not introduce any side effects. Both `substr()` and `slice()` have similar behavior, with the exception of how they handle negative indices. All instances in the codebase have been reviewed to ensure compatibility.

### Additional Context
For more information on the deprecation of `substr()`, please refer to the MDN documentation: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr.
