### PR TITLE
deps: mocha@9.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "middleware"
   ],
   "dependencies": {
-    "cookie": "^0.7.2",
+    "cookie": "0.7.2",
     "cookie-signature": "1.0.6"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "middleware"
   ],
   "dependencies": {
-    "cookie": "0.4.2",
+    "cookie": "^0.7.2",
     "cookie-signature": "1.0.6"
   },
   "devDependencies": {
@@ -24,7 +24,7 @@
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-promise": "4.3.1",
     "eslint-plugin-standard": "4.1.0",
-    "mocha": "9.2.1",
+    "mocha": "^9.2.2",
     "nyc": "15.1.0",
     "supertest": "6.1.6"
   },


### PR DESCRIPTION
Seing that the mocha and cookie packages has a vulnerability on older versions, i decided to upgraded the packages to remove the vulnerabilities, and decided to change the version text adding a "^" so that in the future, new updates of this packages will be installed instead of a fixed version, it may be better to use "~" for only bug fixes.